### PR TITLE
Use default arguments to remove boilerplate code

### DIFF
--- a/Sources/CloudEnvironment/CloudEnvironment.swift
+++ b/Sources/CloudEnvironment/CloudEnvironment.swift
@@ -17,16 +17,12 @@
 import SwiftyJSON
 
 /**
-* Functions as a factory to create instances of the AppEnv structure.
-*/
+ * Functions as a factory to create instances of the AppEnv structure.
+ */
 public struct CloudEnvironment {
-  public static func getAppEnv(options: JSON) throws -> AppEnv {
-    return try AppEnv(options: options)
-}
 
-  public static func getAppEnv() throws -> AppEnv  {
-   let options:JSON = [:]
-   return try getAppEnv(options: options)
- }
+  public static func getAppEnv(options: JSON = [:]) throws -> AppEnv {
+    return try AppEnv(options: options)
+  }
 
 }


### PR DESCRIPTION
This removes one full function declaration at the expense of specifying a default argument.

(Also includes minor improvements to the indentation in that file.)