### PR TITLE
removed logger from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,13 +29,12 @@ let package = Package(
     ],
     dependencies: [
         //.Package(url: "https://github.com/behrang/YamlSwift.git", majorVersion: 1),
-        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.7.0")),
         .package(url: "https://github.com/IBM-Swift/Configuration.git", .upToNextMajor(from: "3.0.0")),
     ],
     targets: [
         .target(
             name: "CloudFoundryEnv",
-            dependencies: ["LoggerAPI", "Configuration"]
+            dependencies: ["Configuration"]
         ),
         .testTarget(
             name: "CloudFoundryEnvTests",


### PR DESCRIPTION
## Description
Logger was brought in Configuration and so does not need to be explicitly declared in the package.swift file.

## How Has This Been Tested?
Swift test was run and all tests pass. This change should have no impact of code functionality.
